### PR TITLE
docs: update connector description

### DIFF
--- a/docs/connector.mdx
+++ b/docs/connector.mdx
@@ -1,8 +1,8 @@
 ---
 title: "Set up a Google BigQuery connector"
 og:title: "Set up a Google BigQuery connector"
-description: "C1 provides identity governance and just-in-time provisioning for Google BigQuery. Integrate your Google BigQuery instance with C1 to run user access reviews (UARs), enable just-in-time access requests, and automatically provision and deprovision access."
-og:description: "C1 provides identity governance and just-in-time provisioning for Google BigQuery. Integrate your Google BigQuery instance with C1 to run user access reviews (UARs), enable just-in-time access requests, and automatically provision and deprovision access."
+description: "C1 provides identity governance for Google BigQuery. Integrate your Google BigQuery instance with C1 for unified visibility and governance over user access."
+og:description: "C1 provides identity governance for Google BigQuery. Integrate your Google BigQuery instance with C1 for unified visibility and governance over user access."
 sidebarTitle: "Google BigQuery"
 ---
 
@@ -74,7 +74,7 @@ Click **Close**.
 </Step>
 </Steps> 
 
-**That's it!** Next, move on to the connector configuration instructions. 
+**Done.** Next, move on to the connector configuration instructions. 
 
 ## Configure the Google BigQuery connector
 
@@ -127,7 +127,7 @@ The connector's label changes to **Syncing**, followed by **Connected**. You can
 </Step>
 </Steps>
 
-**That's it!** Your Google BigQuery connector is now pulling access data into C1.
+**Done.** Your Google BigQuery connector is now pulling access data into C1.
 </Tab>
 
 <Tab title="Self-hosted">
@@ -245,7 +245,7 @@ Check that the connector data uploaded correctly. In C1, click **Apps**. On the 
 </Step>
 </Steps>
 
-**That's it!** Your Google BigQuery connector is now pulling access data into C1.
+**Done.** Your Google BigQuery connector is now pulling access data into C1.
 </Tab>
 </Tabs>
 


### PR DESCRIPTION
Replicates changes from [ConductorOne/docs#221](https://github.com/ConductorOne/docs/pull/221).

- Removes inaccurate provisioning claims from the connector description
- Updates `**That's it!**` to `**Done.**` to align with brand voice guidelines